### PR TITLE
Update apis.json

### DIFF
--- a/apis.json
+++ b/apis.json
@@ -9,7 +9,7 @@
 	"url": "http://sms.apievangelist.com/apis.json",
 	"specificationVersion": "0.14",
 	"apis": [],
-	"includes": [{
+	"include": [{
 		"name": "Clickatell",
 		"url": "http://sms.apievangelist.com/data/clickatell/apis.json"
 	},


### PR DESCRIPTION
You had a typo in the definition - **includes** instead of **include** according to the [APIs.json format spec](http://apisjson.org/format/apisjson_0.14.txt).  Could not visualize the links in **swagger.ed**.   To be honest, the plural version of the attribute makes more sense though.