### PR TITLE
Unparseable swagger definitions due to bad version type (number instead of string)

### DIFF
--- a/data/clickatell/clickatell-sms.json
+++ b/data/clickatell/clickatell-sms.json
@@ -1,5 +1,5 @@
 {
-	"swagger": 2,
+	"swagger": "2.0",
 	"info": {
 		"title": "Clickatell SMS",
 		"description": "The Clickatell HTTP/S API provides just about the simplest way of programming your connection to Clickatell, and if you need to overcome a firewall problem HTTP/S is almost certainly your best solution.",

--- a/data/clockwork/clockwork-sms.json
+++ b/data/clockwork/clockwork-sms.json
@@ -1,5 +1,5 @@
 {
-	"swagger": 2,
+	"swagger": "2.0",
 	"info": {
 		"title": "Clockwork SMS",
 		"description": "The HTTP interface to send text messages can be accessed using GET or POST. All parameters must be URL Encoded and sent as UTF-8 text.",

--- a/data/developer-garden/developer-garden-sms-api.json
+++ b/data/developer-garden/developer-garden-sms-api.json
@@ -1,5 +1,5 @@
 {
-	"swagger": 2,
+	"swagger": "2.0",
 	"info": {
 		"title": "Developer Garden SMS API",
 		"description": "The Global SMS service allows sending SMS messages to mobile phones and receive text messages from a webservice for a specific number.",

--- a/data/messente/messente-sms-api.json
+++ b/data/messente/messente-sms-api.json
@@ -1,5 +1,5 @@
 {
-	"swagger": 2,
+	"swagger": "2.0",
 	"info": {
 		"title": "Messente SMS API",
 		"description": " Sending SMS text messages",

--- a/data/mogreet/mogreet-messaging-api.json
+++ b/data/mogreet/mogreet-messaging-api.json
@@ -1,5 +1,5 @@
 {
-	"swagger": 2,
+	"swagger": "2.0",
 	"info": {
 		"title": "Mogreet Messaging API",
 		"description": "The Mogreet API lets you send and receive text or multimedia messages in minutes. ",

--- a/data/nexmo/nexmo-sms-api.json
+++ b/data/nexmo/nexmo-sms-api.json
@@ -1,5 +1,5 @@
 {
-	"swagger": 2,
+	"swagger": "2.0",
 	"info": {
 		"title": "Nexmo SMS API",
 		"description": "Nexmo makes it simple to send and receive a high volume of SMS anywhere in the world within minutes.",

--- a/data/plivo/plivo-sms.json
+++ b/data/plivo/plivo-sms.json
@@ -1,5 +1,5 @@
 {
-	"swagger": 2,
+	"swagger": "2.0",
 	"info": {
 		"title": "Plivo SMS",
 		"description": null,

--- a/data/telapi/telapi.json
+++ b/data/telapi/telapi.json
@@ -1,5 +1,5 @@
 {
-	"swagger": 2,
+	"swagger": "2.0",
 	"info": {
 		"title": "TelAPI",
 		"description": "TelAPI is a REST API. What that means for you is that interacting with TelAPI to perform all of your telephony needs is almost as simple as visiting a website. Deeper knowledge regarding REST is useful when developing with TelAPI but definitely not required. We aim to provide all of the information needed for working with our REST API throughout its documentation provided here, so even if you are new to REST, TelAPI will still be a pleasure to use.",

--- a/data/twilio/twilio-messaging-api.json
+++ b/data/twilio/twilio-messaging-api.json
@@ -1,5 +1,5 @@
 {
-	"swagger": 2,
+	"swagger": "2.0",
 	"info": {
 		"title": "Twilio Messaging API",
 		"description": "A Message instance resource represents an inbound or outbound message. When you send an SMS or MMS message via the REST API, use the <Message> verb in TwiML, or someone sends a message to one of your Twilio numbers Twilio creates a Message instance resource.",


### PR DESCRIPTION
These Swagger definitions had a version value of 2 (numeric) instead of "2.0" (string) which is required according to the [spec](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#swagger-object).  Not sure how you generated the files, but 3rd party parsers won't work due to this error.

If you don't mind, I'll go through the rest of the API definitions you have created in different blogs and fix the problematic ones.